### PR TITLE
Improve actor embed

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -178,9 +178,9 @@
         "talents": "Talents",
         "drawback": "Drawback",
         "minionGroups": "A group of minions has a Health score equal to their number",
-        "knowPowers": "Know Powers",
-        "knowTalents": "Know Talents",
-        "knowDrawbacks": "Know Drawbacks"
+        "knownPowers": "Known Powers",
+        "knownTalents": "Known Talents",
+        "knownDrawbacks": "Known Drawbacks"
       }
     },
     "Item": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -174,6 +174,10 @@
         }
       },
       "Embed": {
+        "gear": "Gear",
+        "talents": "Talents",
+        "drawback": "Drawback",
+        "minionGroups": "A group of minions has a Health score equal to their number",
         "knowPowers": "Know Powers",
         "knowTalents": "Know Talents",
         "knowDrawbacks": "Know Drawbacks"

--- a/scss/book/components/_embed.scss
+++ b/scss/book/components/_embed.scss
@@ -4,22 +4,29 @@ figure.content-embed {
 
       img.portrait {
         max-height: 210px;
-        margin-left: $default-margin;
+        margin-left: $default-margin !important;
         margin-bottom: calc($default-margin / 2);
+        shape-margin: 16px;
         float: right;
         box-shadow: none;
       }
 
-      div {
-        &:not(:last-child) {
-          border-bottom: 1px solid $c-darkblue;
-        }
 
+      & > div:not(:last-child) {
+        border-bottom: 1px solid $c-darkblue;
+
+        &.talents,
+        &:has(+ .talents) {
+          border-bottom: 0;
+        }
+      }
+
+      div {
         label {
           font-size: var(--font-size-16);
         }
 
-        p {
+        &:not(.biography) p {
           text-align: start;
           hyphens: none;
         }
@@ -74,7 +81,7 @@ figure.content-embed {
 
       div.header,
       div.biography,
-      div.derived {
+      div.derived:not(.non-hero) {
         border-bottom: 0;
       }
 
@@ -85,15 +92,17 @@ figure.content-embed {
       div.powers,
       div.talents,
       div.drawbacks {
-        border-bottom: 0;
         margin-top: $default-margin;
 
-        &>p:first-child {
+        & > p:first-child {
           border-bottom: 1px solid $c-darkblue;
         }
       }
 
-      div.power-source>label {
+      div.power-source {
+        border-bottom: 1px solid $c-darkblue;
+
+        &>label {
         float: left;
         margin-right: 5px;
 
@@ -101,6 +110,7 @@ figure.content-embed {
           text-transform: uppercase;
         }
       }
+    }
 
       div.power,
       div.drawback,
@@ -143,21 +153,35 @@ figure.content-embed {
 
     div.non-hero {
       margin-top: 0 !important;
-      border-top: 1px solid $c-darkblue;
-      p { border-bottom: none !important; }
+      strong {
+        text-transform: capitalize;
+      }
 
-
-      &:has(.drawback) {
-        border-bottom: none !important;
-
+      &.drawback {
         .drawback label strong {
           text-transform: none !important;
+        }
+      }
+
+      &.talents {
+        border-top: 1px solid $c-darkblue;
+        border-bottom: 1px solid $c-darkblue !important;
+
+        p { border: 0 !important; }
+
+        strong:first-child {
+          @extend .small-caps;
+          margin-right: calc($default-margin * 0.25);
+        } 
+
+        p:not(:last-child) {
+          float: left !important;
         }
       }
     }
 
     div.gears {
-      border-top: 1px solid $c-darkblue;
+      clear: both;
       strong { @extend .small-caps }
     }
   }

--- a/scss/book/components/_embed.scss
+++ b/scss/book/components/_embed.scss
@@ -19,6 +19,11 @@ figure.content-embed {
           font-size: var(--font-size-16);
         }
 
+        p {
+          text-align: start;
+          hyphens: none;
+        }
+
         p,
         label {
           color: $c-darkblue;
@@ -134,6 +139,29 @@ figure.content-embed {
         float: left;
         left: calc($default-margin * 2.7);
       }
+    }
+
+    div.non-hero {
+      margin-top: 0 !important;
+      border-top: 1px solid $c-darkblue;
+      p { border-bottom: none !important; }
+
+
+      &:has(.drawback) {
+        border-bottom: none !important;
+
+        .drawback label strong {
+          text-transform: none !important;
+        }
+      }
+
+  
+
+    }
+
+    div.gears {
+      border-top: 1px solid $c-darkblue;
+      strong { @extend .small-caps }
     }
   }
 

--- a/scss/book/components/_embed.scss
+++ b/scss/book/components/_embed.scss
@@ -154,9 +154,6 @@ figure.content-embed {
           text-transform: none !important;
         }
       }
-
-  
-
     }
 
     div.gears {

--- a/scss/book/components/_embed.scss
+++ b/scss/book/components/_embed.scss
@@ -27,6 +27,13 @@ figure.content-embed {
         }
       }
 
+      ul {
+        margin: 0;
+        li::before {
+          background-image: url(../assets/book/icons/star-darkblue.svg); 
+        }
+      }
+
       div.header {
         display: flex;
       }
@@ -97,12 +104,15 @@ figure.content-embed {
         padding-left: $default-margin;
 
         &::before {
-          //TODO: check this symbol
-          content: "*";
+          content: "";
+          background-image: url(../assets/book/icons/star-darkblue.svg); 
           color: $c-darkblue;
+          width: $default-margin;
+          height: $default-margin;
           float: left;
           position: absolute;
-          left: calc($default-margin * 1.7);
+          left: calc($default-margin) * 1.5;
+          margin-top: 0.2rem;
           font-size: 24px;
         }
 
@@ -118,7 +128,10 @@ figure.content-embed {
       }
 
       div.boostLimit::before {
-        //TODO: check this symbol
+        background-image: none;
+        content: "⦾"; 
+        font-size: 0.8rem;
+        float: left;
         left: calc($default-margin * 2.7);
       }
     }

--- a/system/models/actors/base-actor.mjs
+++ b/system/models/actors/base-actor.mjs
@@ -216,6 +216,7 @@ export default class InvincibleActorBase extends foundry.abstract.TypeDataModel 
     }
 
     await this.prepareItems(context);
+    context.isKnowTalentsDrawbacks = ['superhero'].includes(context.actor.type) ? true : false;
     context.hasReputation = context.actor.system.reputation + context.actor.system.resources;
     const content = await foundry.applications.handlebars.renderTemplate(this.EMBED_TEMPLATE, context);
     const result = document.createElement("div");

--- a/system/models/actors/base-actor.mjs
+++ b/system/models/actors/base-actor.mjs
@@ -216,7 +216,6 @@ export default class InvincibleActorBase extends foundry.abstract.TypeDataModel 
     }
 
     await this.prepareItems(context);
-    debugger
     context.hasReputation = context.actor.system.reputation + context.actor.system.resources;
     const content = await foundry.applications.handlebars.renderTemplate(this.EMBED_TEMPLATE, context);
     const result = document.createElement("div");

--- a/system/models/actors/base-actor.mjs
+++ b/system/models/actors/base-actor.mjs
@@ -215,9 +215,10 @@ export default class InvincibleActorBase extends foundry.abstract.TypeDataModel 
       config
     }
 
+
+
     await this.prepareItems(context);
-    context.isKnownTalentsDrawbacks = ['superhero'].includes(context.actor.type) ? true : false;
-    context.hasReputation = context.actor.system.reputation + context.actor.system.resources;
+    context.hasReputationOrResources = context.actor.system.reputation + context.actor.system.resources;
     const content = await foundry.applications.handlebars.renderTemplate(this.EMBED_TEMPLATE, context);
     const result = document.createElement("div");
     result.innerHTML = content;

--- a/system/models/actors/base-actor.mjs
+++ b/system/models/actors/base-actor.mjs
@@ -215,8 +215,6 @@ export default class InvincibleActorBase extends foundry.abstract.TypeDataModel 
       config
     }
 
-
-
     await this.prepareItems(context);
     context.hasReputationOrResources = context.actor.system.reputation + context.actor.system.resources;
     const content = await foundry.applications.handlebars.renderTemplate(this.EMBED_TEMPLATE, context);

--- a/system/models/actors/base-actor.mjs
+++ b/system/models/actors/base-actor.mjs
@@ -216,7 +216,7 @@ export default class InvincibleActorBase extends foundry.abstract.TypeDataModel 
     }
 
     await this.prepareItems(context);
-    context.isKnowTalentsDrawbacks = ['superhero'].includes(context.actor.type) ? true : false;
+    context.isKnownTalentsDrawbacks = ['superhero'].includes(context.actor.type) ? true : false;
     context.hasReputation = context.actor.system.reputation + context.actor.system.resources;
     const content = await foundry.applications.handlebars.renderTemplate(this.EMBED_TEMPLATE, context);
     const result = document.createElement("div");

--- a/system/models/actors/base-actor.mjs
+++ b/system/models/actors/base-actor.mjs
@@ -214,7 +214,10 @@ export default class InvincibleActorBase extends foundry.abstract.TypeDataModel 
       options,
       config
     }
+
     await this.prepareItems(context);
+    debugger
+    context.hasReputation = context.actor.system.reputation + context.actor.system.resources;
     const content = await foundry.applications.handlebars.renderTemplate(this.EMBED_TEMPLATE, context);
     const result = document.createElement("div");
     result.innerHTML = content;

--- a/templates/embeds/actor.hbs
+++ b/templates/embeds/actor.hbs
@@ -62,12 +62,15 @@
     <div class="derived">
       <p>
         <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.derived.health.value.label"}}:</strong>
-        {{actor.system.derived.health.max}}
+        {{actor.system.derived.health.max}}{{#if (eq actor.type "minions")}}*{{/if}}
         <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.derived.resolve.value.label"}}:</strong>
         {{actor.system.derived.resolve.max}}
         <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.derived.slugfest.damage"}}:</strong>
         {{actor.system.derived.slugfest.max}}
       </p>
+      {{#if (eq actor.type "minions")}}
+        <p>*{{localize "INVINCIBLE.Actor.Embed.minionGroups"}}</p>
+      {{/if}}
     </div>
     
     {{#if powers}}
@@ -107,26 +110,67 @@
     </div> 
     {{/if}}
     {{#if talents}}
-    <div class="talents">
-      <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowTalents"}}</strong></p>
-      <p>
-        {{#each talents as | talent |}}
-        {{talent.name}}{{ifThen (not @last) ", " ""}}
-        {{/each}}
-      </p>
-    </div>
+      {{#unless isKnowTalentsDrawbacks}}
+      <div class="talents non-hero">
+        <p><strong>{{localize "INVINCIBLE.Actor.Embed.talents"}}: </strong>
+          {{#each talents as | talent |}}
+          {{talent.name}}{{ifThen (not @last) ", " ""}}
+          {{/each}}
+        </p>
+      </div>
+      {{/unless}}
+
+      {{#if isKnowTalentsDrawbacks}}
+      <div class="talents">
+        <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowTalents"}}</strong></p>
+        <p>
+          {{#each talents as | talent |}}
+          {{talent.name}}{{ifThen (not @last) ", " ""}}
+          {{/each}}
+        </p>
+      </div>
+      {{/if}}
+  
     {{/if}}
     {{#if drawbacks}}
-    <div class="drawbacks">
-      <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowDrawbacks"}}</strong></p>
-      {{#each drawbacks as | drawback |}}
-      <div class="drawback">
-        <label>
-          <strong>{{drawback.name}}</strong>.
-        </label>
-        {{{drawback.enriched}}}
+
+      {{#unless isKnowTalentsDrawbacks}}
+         <div class="non-hero">
+            {{#each drawbacks as | drawback |}}
+              <div class="drawback">
+                <label>
+                  <strong>{{localize "INVINCIBLE.Actor.Embed.drawback"}}: {{drawback.name}}</strong>.
+                </label>
+                {{{drawback.enriched}}}
+              </div>
+            {{/each}}
+          </div>
+      {{/unless}}
+
+      {{#if isKnowTalentsDrawbacks}}
+        <div class="drawbacks">
+          <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowDrawbacks"}}</strong></p>
+          {{#each drawbacks as | drawback |}}
+          <div class="drawback">
+            <label>
+              <strong>{{drawback.name}}</strong>.
+            </label>
+            {{{drawback.enriched}}}
+          </div>
+          {{/each}}
+        </div>
+      {{/if}}
+
+
+    {{/if}}
+    {{#if gear}}
+    <div class="gears">
+      <p><strong>{{localize "INVINCIBLE.Actor.Embed.gear"}}: </strong>
+        {{#each gear as | g |}}
+        {{g.name}}{{ifThen g.system.extraInfo (concat " " g.system.extraInfo) "" }}{{ifThen (not @last) ", " ""}}
+        {{/each}}
+      </p>
       </div>
-      {{/each}}
     </div>
     {{/if}}
   </div>

--- a/templates/embeds/actor.hbs
+++ b/templates/embeds/actor.hbs
@@ -110,7 +110,7 @@
     </div> 
     {{/if}}
     {{#if talents}}
-      {{#unless isKnowTalentsDrawbacks}}
+      {{#unless isKnownTalentsDrawbacks}}
       <div class="talents non-hero">
         <p><strong>{{localize "INVINCIBLE.Actor.Embed.talents"}}: </strong>
           {{#each talents as | talent |}}
@@ -119,8 +119,7 @@
         </p>
       </div>
       {{/unless}}
-
-      {{#if isKnowTalentsDrawbacks}}
+      {{#if isKnownTalentsDrawbacks}}
       <div class="talents">
         <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowTalents"}}</strong></p>
         <p>
@@ -130,11 +129,9 @@
         </p>
       </div>
       {{/if}}
-  
     {{/if}}
     {{#if drawbacks}}
-
-      {{#unless isKnowTalentsDrawbacks}}
+      {{#unless isKnownTalentsDrawbacks}}
          <div class="non-hero">
             {{#each drawbacks as | drawback |}}
               <div class="drawback">
@@ -146,8 +143,7 @@
             {{/each}}
           </div>
       {{/unless}}
-
-      {{#if isKnowTalentsDrawbacks}}
+      {{#if isKnownTalentsDrawbacks}}
         <div class="drawbacks">
           <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowDrawbacks"}}</strong></p>
           {{#each drawbacks as | drawback |}}
@@ -160,8 +156,6 @@
           {{/each}}
         </div>
       {{/if}}
-
-
     {{/if}}
     {{#if gear}}
     <div class="gears">

--- a/templates/embeds/actor.hbs
+++ b/templates/embeds/actor.hbs
@@ -69,6 +69,8 @@
         {{actor.system.derived.slugfest.max}}
       </p>
     </div>
+    
+    {{#if powers}}
     <div class="powers">
       <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowPowers"}}</strong></p>
       {{#each powers as | ps i |}}
@@ -102,7 +104,8 @@
       </div>
       {{/each}}
       {{/each}}
-    </div>
+    </div> 
+    {{/if}}
     {{#if talents}}
     <div class="talents">
       <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowTalents"}}</strong></p>

--- a/templates/embeds/actor.hbs
+++ b/templates/embeds/actor.hbs
@@ -7,29 +7,45 @@
       <div class="attribute name">
         <p><strong>{{actor.name}}</strong></p>
       </div>
+      {{#if config.asOf}}
       <p class="as-of">{{config.asOf}}</p>
+      {{/if}}
     </div>
     <div class="biography">
       {{{actor.system.biography}}}
     </div>
     <div class="role">
       <p>
+        {{#if actor.system.role}}
         <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.role.label"}}</strong>: {{actor.system.role}}
+        {{/if}}
+        {{#if actor.system.occupation}}
         <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.occupation.label"}}</strong>: {{actor.system.occupation}}
+        {{/if}}
+        {{#if actor.system.personality}}
         <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.personality.label"}}</strong>: {{actor.system.personality}}
+        {{/if}}
+        {{#if actor.system.drive}}
         <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.drive.label"}}</strong>: {{actor.system.drive}}
+        {{/if}}
+        {{#if actor.system.flaw}}
         <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.flaw.label"}}</strong>: {{actor.system.flaw}}
+        {{/if}}
+        
       </p>
     </div>
     {{#if (not config.hideReputation)}}
-    <div class="reputation">
-      <p>
-        <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.reputation.label"}}:</strong>
-        {{actor.system.reputation}}
-        <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.resources.label"}}:</strong>
-        {{actor.system.resources}}
-      </p>
-    </div>
+      {{log this leve="warn"}}
+      {{#if hasReputation}}
+      <div class="reputation">
+        <p>
+          <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.reputation.label"}}:</strong>
+          {{actor.system.reputation}}
+          <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.resources.label"}}:</strong>
+          {{actor.system.resources}}
+        </p>
+      </div>
+      {{/if}}
     {{/if}}
     <div class="attributes">
       <p>

--- a/templates/embeds/actor.hbs
+++ b/templates/embeds/actor.hbs
@@ -1,7 +1,7 @@
 <div id="invbook">
   <div class="invincible-actor">
     {{#if (not config.hideImg)}}
-    <img class="portrait" src="{{actor.img}}" />
+    <img class="portrait" src="{{actor.img}}" style="shape-outside: url({{actor.img}});" />
     {{/if}}
     <div class="header">
       <div class="attribute name">
@@ -34,9 +34,7 @@
         
       </p>
     </div>
-    {{#if (not config.hideReputation)}}
-      {{log this leve="warn"}}
-      {{#if hasReputation}}
+    {{#if (and hasReputationOrResources (not config.hideReputation))}}
       <div class="reputation">
         <p>
           <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.reputation.label"}}:</strong>
@@ -45,7 +43,6 @@
           {{actor.system.resources}}
         </p>
       </div>
-      {{/if}}
     {{/if}}
     <div class="attributes">
       <p>
@@ -59,7 +56,7 @@
         {{/each}}
       </p>
     </div>
-    <div class="derived">
+    <div class="derived {{#if (not (eq actor.type "superhero"))}}non-hero{{/if}}">
       <p>
         <strong>{{localize "INVINCIBLE.Actor.base.FIELDS.derived.health.value.label"}}:</strong>
         {{actor.system.derived.health.max}}{{#if (eq actor.type "minions")}}*{{/if}}
@@ -74,8 +71,8 @@
     </div>
     
     {{#if powers}}
-    <div class="powers">
-      <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowPowers"}}</strong></p>
+    <div class="powers {{#if (not (eq actor.type "superhero"))}}non-hero{{/if}}">
+      {{#if (eq actor.type "superhero")}}<p><strong>{{localize "INVINCIBLE.Actor.Embed.knownPowers"}}</strong></p>{{/if}}
       {{#each powers as | ps i |}}
       <div class="power-source">
         <label>
@@ -110,52 +107,31 @@
     </div> 
     {{/if}}
     {{#if talents}}
-      {{#unless isKnownTalentsDrawbacks}}
-      <div class="talents non-hero">
-        <p><strong>{{localize "INVINCIBLE.Actor.Embed.talents"}}: </strong>
-          {{#each talents as | talent |}}
-          {{talent.name}}{{ifThen (not @last) ", " ""}}
-          {{/each}}
-        </p>
-      </div>
-      {{/unless}}
-      {{#if isKnownTalentsDrawbacks}}
-      <div class="talents">
-        <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowTalents"}}</strong></p>
-        <p>
-          {{#each talents as | talent |}}
-          {{talent.name}}{{ifThen (not @last) ", " ""}}
-          {{/each}}
-        </p>
-      </div>
-      {{/if}}
+
+    <div class="talents {{#if (not (eq actor.type "superhero"))}}non-hero{{/if}}">
+      <p><strong>{{#if (not (eq actor.type "superhero"))}}{{localize "INVINCIBLE.Actor.Embed.talents"}}: {{else}}{{localize "INVINCIBLE.Actor.Embed.knownTalents"}}{{/if}}</strong></p>
+      <p>
+        {{#each talents as | talent |}}
+        {{talent.name}}{{ifThen (not @last) ", " ""}}
+        {{/each}}
+      </p>
+    </div>
+
     {{/if}}
     {{#if drawbacks}}
-      {{#unless isKnownTalentsDrawbacks}}
-         <div class="non-hero">
-            {{#each drawbacks as | drawback |}}
-              <div class="drawback">
-                <label>
-                  <strong>{{localize "INVINCIBLE.Actor.Embed.drawback"}}: {{drawback.name}}</strong>.
-                </label>
-                {{{drawback.enriched}}}
-              </div>
-            {{/each}}
-          </div>
-      {{/unless}}
-      {{#if isKnownTalentsDrawbacks}}
-        <div class="drawbacks">
-          <p><strong>{{localize "INVINCIBLE.Actor.Embed.knowDrawbacks"}}</strong></p>
-          {{#each drawbacks as | drawback |}}
-          <div class="drawback">
-            <label>
-              <strong>{{drawback.name}}</strong>.
-            </label>
-            {{{drawback.enriched}}}
-          </div>
-          {{/each}}
-        </div>
+    <div class="drawbacks {{#if (not (eq actor.type "superhero"))}}non-hero{{/if}}">
+      {{#if (eq actor.type "superhero")}}
+        <p><strong>{{localize "INVINCIBLE.Actor.Embed.knownDrawbacks"}}</strong></p>
       {{/if}}
+      {{#each drawbacks as | drawback |}}
+      <div class="drawback">
+      <label>
+      <strong>{{#if (not (eq actor.type "superhero"))}}{{localize "INVINCIBLE.Actor.Embed.drawback"}}: {{/if}}{{drawback.name}}</strong>.
+      </label>
+      {{{drawback.enriched}}}
+      </div>
+      {{/each}}
+    </div>
     {{/if}}
     {{#if gear}}
     <div class="gears">

--- a/templates/embeds/actor.hbs
+++ b/templates/embeds/actor.hbs
@@ -69,7 +69,6 @@
         <p>*{{localize "INVINCIBLE.Actor.Embed.minionGroups"}}</p>
       {{/if}}
     </div>
-    
     {{#if powers}}
     <div class="powers {{#if (not (eq actor.type "superhero"))}}non-hero{{/if}}">
       {{#if (eq actor.type "superhero")}}<p><strong>{{localize "INVINCIBLE.Actor.Embed.knownPowers"}}</strong></p>{{/if}}
@@ -107,7 +106,6 @@
     </div> 
     {{/if}}
     {{#if talents}}
-
     <div class="talents {{#if (not (eq actor.type "superhero"))}}non-hero{{/if}}">
       <p><strong>{{#if (not (eq actor.type "superhero"))}}{{localize "INVINCIBLE.Actor.Embed.talents"}}: {{else}}{{localize "INVINCIBLE.Actor.Embed.knownTalents"}}{{/if}}</strong></p>
       <p>
@@ -116,7 +114,6 @@
         {{/each}}
       </p>
     </div>
-
     {{/if}}
     {{#if drawbacks}}
     <div class="drawbacks {{#if (not (eq actor.type "superhero"))}}non-hero{{/if}}">


### PR DESCRIPTION
Improve actor embed:

- If actor is minion add "A group of minions has a Health score equal to their number" and * after Health
- `isKnowTalentsDrawbacks`: used to check which formatation we should use: simple (for npc, minions) or known talents/drawbacks (superheroes)
- Update embed styles for `isKnowTalentsDrawbacks`
- Add gears to embed
- Update en.json with necessary localization fields

Minor fixes:
- Update `::before` of `.boostLimit`
- Update ul margins of item descriptions inside actor sheet